### PR TITLE
Fix  identifier names exceeding 64 characters

### DIFF
--- a/src/formatter/formatter.go
+++ b/src/formatter/formatter.go
@@ -3,19 +3,27 @@ package formatter
 import (
 	"fmt"
 	"strings"
+	"strconv"
 
 	"github.com/syucream/hakagi/src/constraint"
 )
 
 const (
 	baseSql = "ALTER TABLE %s ADD CONSTRAINT FOREIGN KEY (%s) REFERENCES %s(%s);"
+	customSql = "ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s);"
 )
 
 func FormatSql(constraints []constraint.Constraint) string {
 	var queries []string
 
-	for _, c := range constraints {
-		q := fmt.Sprintf(baseSql, c.Table, c.Column, c.ReferedTable, c.ReferedColumn)
+	for i := 1, c := range constraints {
+	  if len(c.Table) >= 57 {
+			fk_name := c.Table[57] + "_ibfk_" + strconv.Itoa(i)
+			q := fmt.Sprintf(customSql, c.Table, fk_name, c.Column, c.ReferedTable, c.ReferedColumn)
+		} else {
+			q := fmt.Sprintf(baseSql, c.Table, c.Column, c.ReferedTable, c.ReferedColumn)
+		}
+
 		queries = append(queries, q)
 	}
 


### PR DESCRIPTION
外部キー名が64文字を超えた場合にエラーとなるため対応
https://dev.mysql.com/doc/refman/8.0/ja/identifier-length.html

```
ERROR 1059 (42000) at line 115: Identifier name 'too_long_table_name' is too long
```

識別子名を指定して対応できないか、試してみる